### PR TITLE
Update rav1e from 0.3.5 to 0.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -136,9 +136,9 @@ ARG XVID_SHA256=abbdcbd39555691dd1c9b4d08f0a031376a3b211652c0d8b3b8aa9be1303ce2d
 # bump: rav1e /RAV1E_VERSION=([\d.]+)/ https://github.com/xiph/rav1e.git|^0
 # bump: rav1e after ./hashupdate Dockerfile RAV1E $LATEST
 # bump: rav1e link "Release notes" https://github.com/xiph/rav1e/releases/tag/v$LATEST
-ARG RAV1E_VERSION=0.3.5
+ARG RAV1E_VERSION=0.4.0
 ARG RAV1E_URL="https://github.com/xiph/rav1e/archive/v$RAV1E_VERSION.tar.gz"
-ARG RAV1E_SHA256=ab97209f52695dce740cffb61b0f53b53db5682bfbdd1dfbaf8c93ee36a69a84
+ARG RAV1E_SHA256=c3ea1a2275f09c8a8964084c094d81f01c07fb405930633164ba69d0613a9003
 # bump: srt /SRT_VERSION=([\d.]+)/ https://github.com/Haivision/srt.git|^1
 # bump: srt after ./hashupdate Dockerfile SRT $LATEST
 # bump: srt link "Release notes" https://github.com/Haivision/srt/releases/tag/v$LATEST


### PR DESCRIPTION
[Release notes](https://github.com/xiph/rav1e/releases/tag/v0.4.0)  
