### PR TITLE
Update alpine from 3.13.5 to 3.14.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # bump: alpine /FROM alpine:([\d.]+)/ docker:alpine|^3
 # bump: alpine link "Release notes" https://alpinelinux.org/posts/Alpine-$LATEST-released.html
-FROM alpine:3.13.5 AS builder
+FROM alpine:3.14.0 AS builder
 
 # bump: ffmpeg /FFMPEG_VERSION=([\d.]+)/ https://github.com/FFmpeg/FFmpeg.git|^4
 # bump: ffmpeg after ./hashupdate Dockerfile FFMPEG $LATEST
@@ -239,12 +239,6 @@ RUN apk add --no-cache \
 
 # cargo-c is not in stable main yet
 RUN apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing cargo-c
-
-# workaround for https://github.com/google/brotli/issues/795
-# pkgconfig --static can't have different name than .so
-RUN \
-  ln -s /usr/lib/libbrotlicommon-static.a /usr/lib/libbrotlicommon.a && \
-  ln -s /usr/lib/libbrotlidec-static.a /usr/lib/libbrotlidec.a
 
 RUN \
   OPENSSL_VERSION=$(pkg-config --modversion openssl) \


### PR DESCRIPTION
[Release notes](https://alpinelinux.org/posts/Alpine-3.14.0-released.html)  
