### PR TITLE
Update vmaf from 2.1.1 to 2.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,9 +167,9 @@ ARG XAVS2_SHA256=28f9204dc9384336de7c6210cd3317d2d6b94ec23a4d1b6113fcbe7f00d7230
 # bump: vmaf after ./hashupdate Dockerfile VMAF $LATEST
 # bump: vmaf link "Release" https://github.com/Netflix/vmaf/releases/tag/v$LATEST
 # bump: vmaf link "Source diff $CURRENT..$LATEST" https://github.com/Netflix/vmaf/compare/v$CURRENT..v$LATEST
-ARG VMAF_VERSION=2.1.1
+ARG VMAF_VERSION=2.2.0
 ARG VMAF_URL="https://github.com/Netflix/vmaf/archive/refs/tags/v$VMAF_VERSION.tar.gz"
-ARG VMAF_SHA256=e7fc00ae1322a7eccfcf6d4f1cdf9c67eec8058709887c8c6c3795c617326f77
+ARG VMAF_SHA256=239e8e70ed2ae7b25f3a6ed9557f28c4ed287d5b1b82ce24da8916106864218f
 
 # -O3 makes sure we compile with optimization. setting CFLAGS/CXXFLAGS seems to override
 # default automake cflags.


### PR DESCRIPTION
[Release](https://github.com/Netflix/vmaf/releases/tag/v2.2.0)  
[Source diff 2.1.1..2.2.0](https://github.com/Netflix/vmaf/compare/v2.1.1..v2.2.0)  
