### PR TITLE
Update rav1e from 0.4.1 to 0.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -159,9 +159,9 @@ ARG XVID_SHA256=abbdcbd39555691dd1c9b4d08f0a031376a3b211652c0d8b3b8aa9be1303ce2d
 # bump: rav1e /RAV1E_VERSION=([\d.]+)/ https://github.com/xiph/rav1e.git|/\d+\./|*
 # bump: rav1e after ./hashupdate Dockerfile RAV1E $LATEST
 # bump: rav1e link "Release notes" https://github.com/xiph/rav1e/releases/tag/v$LATEST
-ARG RAV1E_VERSION=0.4.1
+ARG RAV1E_VERSION=0.5.0
 ARG RAV1E_URL="https://github.com/xiph/rav1e/archive/v$RAV1E_VERSION.tar.gz"
-ARG RAV1E_SHA256=b0be59435a40e03b973ecc551ca7e632e03190b5a20f944818afa3c2ecf4852d
+ARG RAV1E_SHA256=ee56c49dbb50a0810257445e434edb99da01c968da0635403f31bd9677886871
 # bump: srt /SRT_VERSION=([\d.]+)/ https://github.com/Haivision/srt.git|^1
 # bump: srt after ./hashupdate Dockerfile SRT $LATEST
 # bump: srt link "Release notes" https://github.com/Haivision/srt/releases/tag/v$LATEST


### PR DESCRIPTION
[Release notes](https://github.com/xiph/rav1e/releases/tag/v0.5.0)  
