### PR TITLE
Update alpine from 3.14.3 to 3.15.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN cargo install --target=$(./rustup-musl-target $(arch)) --version 0.9.5 cargo
 
 # bump: alpine /FROM alpine:([\d.]+)/ docker:alpine|^3
 # bump: alpine link "Release notes" https://alpinelinux.org/posts/Alpine-$LATEST-released.html
-FROM alpine:3.14.3 AS builder
+FROM alpine:3.15.0 AS builder
 
 # bump: ffmpeg /FFMPEG_VERSION=([\d.]+)/ https://github.com/FFmpeg/FFmpeg.git|^4
 # bump: ffmpeg after ./hashupdate Dockerfile FFMPEG $LATEST


### PR DESCRIPTION
[Release notes](https://alpinelinux.org/posts/Alpine-3.15.0-released.html)  
