### PR TITLE
Update rubberband from 2.0.1 to 2.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -198,9 +198,9 @@ ARG UAVS3D_COMMIT=e58e199ccc50163c20df114db7e3950295c3e2ed
 # bump: rubberband after ./hashupdate Dockerfile RUBBERBAND $LATEST
 # bump: rubberband link "CHANGELOG" https://github.com/breakfastquay/rubberband/blob/default/CHANGELOG
 # bump: rubberband link "Source diff $CURRENT..$LATEST" https://github.com/breakfastquay/rubberband/compare/$CURRENT..$LATEST
-ARG RUBBERBAND_VERSION=2.0.1
+ARG RUBBERBAND_VERSION=2.0.2
 ARG RUBBERBAND_URL="https://breakfastquay.com/files/releases/rubberband-$RUBBERBAND_VERSION.tar.bz2"
-ARG RUBBERBAND_SHA256=dc1b8b775f1717b21e35a11842b00d63beaaf9255b304dee7bb0413568ad80e8
+ARG RUBBERBAND_SHA256=b9eac027e797789ae99611c9eaeaf1c3a44cc804f9c8a0441a0d1d26f3d6bdf9
 # bump: libgme /LIBGME_COMMIT=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/mpyne/game-music-emu.git|re:#^refs/heads/master$#|@commit
 # bump: libgme after ./hashupdate Dockerfile LIBGME $LATEST
 # bump: libgme link "Source diff $CURRENT..$LATEST" https://bitbucket.org/mpyne/game-music-emu/branches/compare/$CURRENT..$LATEST


### PR DESCRIPTION
[CHANGELOG](https://github.com/breakfastquay/rubberband/blob/default/CHANGELOG)  
[Source diff 2.0.1..2.0.2](https://github.com/breakfastquay/rubberband/compare/2.0.1..2.0.2)  
