### PR TITLE
Create workflow for building multiarch image on spot instances

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -31,6 +31,7 @@ jobs:
     uses: pldin601/common-workflows/.github/workflows/build-multiarch-on-aws-spots.yml@v1.0.0
     with:
       DOCKER_IMAGE_TAG: ${{ needs.tag.outputs.TAG }}
+      DOCKER_IMAGE_NAME: "mwader/static-ffmpeg-multi-test"
       WORKFLOW_CHECKOUT: v1.0.0 # Should be equal to the ref used in "uses" expression.
       AWS_REGION: us-east-1
       AWS_EC2_INSTANCE_SIZE: xlarge

--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -28,10 +28,12 @@ jobs:
     needs:
       - tag
     name: Build
-    uses: pldin601/common-workflows/.github/workflows/build-multiarch-on-aws-spots.yml@main
+    uses: pldin601/common-workflows/.github/workflows/build-multiarch-on-aws-spots.yml@v1.0.0
     with:
       DOCKER_IMAGE_TAG: ${{ needs.tag.outputs.TAG }}
-      WORKFLOW_CHECKOUT: main # Should be equal to the ref used in "uses" expression.
+      WORKFLOW_CHECKOUT: v1.0.0 # Should be equal to the ref used in "uses" expression.
+      AWS_REGION: us-east-1
+      AWS_EC2_INSTANCE_SIZE: xlarge
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -1,0 +1,39 @@
+name: "Build multi-arch image"
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - '**'
+
+jobs:
+  tag:
+    name: Extract tag name
+    runs-on: ubuntu-latest
+    outputs:
+      TAG: ${{ steps.tag.outputs.result }}
+    steps:
+      - name: Extract the tag name
+        id: tag
+        uses: actions/github-script@0.2.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            return context.payload.ref === "refs/heads/master"
+              ? 'latest'
+              : context.payload.ref.replace(/^refs\/(tags|heads)\//, '');
+
+  build:
+    needs:
+      - tag
+    name: Build
+    uses: pldin601/common-workflows/.github/workflows/build-multiarch-on-aws-spots.yml@main
+    with:
+      DOCKER_IMAGE_TAG: ${{ needs.tag.outputs.TAG }}
+      WORKFLOW_CHECKOUT: main # Should be equal to the ref used in "uses" expression.
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
To run this workflow the following secrets should be defined:

To spawn instances on the AWS infrastructure:
* AWS_ACCESS_KEY_ID
* AWS_SECRET_ACCESS_KEY

To push resulting images to the docker hub:
* DOCKERHUB_USERNAME
* DOCKERHUB_TOKEN

Refs: #158 #94
