### PR TITLE
adds some config args to build smaller and disable some docs and tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -571,6 +571,7 @@ RUN \
   echo "$FFMPEG_SHA256  ffmpeg.tar.bz2" | sha256sum --status -c - && \
   tar xf ffmpeg.tar.bz2 && \
   cd ffmpeg-* && \
+  echo -n "$FFMPEG_VERSION-static *** https://github.com/wader/static-ffmpeg" > VERSION && \
   sed -i 's/add_ldexeflags -fPIE -pie/add_ldexeflags -fPIE -static-pie/' configure && \
   ./configure \
   --pkg-config-flags="--static" \
@@ -580,6 +581,10 @@ RUN \
   --disable-debug \
   --disable-shared \
   --disable-ffplay \
+  --disable-manpages \
+  --disable-podpages \
+  --disable-large-tests \
+  --enable-small \
   --enable-static \
   --enable-gpl \
   --enable-version3 \


### PR DESCRIPTION
disables some tests and disable building some of the documentation
Adds `--enable-small` to optimize for smaller binary size

tested `--enable-small` with following configure args -> 
```
  configuration:
    --pkg-config-flags=--static
    --extra-cflags=-fopenmp
    --extra-ldflags=-fopenmp
    --toolchain=hardened
    --disable-debug
    --disable-shared
    --disable-ffplay
    --enable-static
    --enable-gpl
    --enable-version3
    --enable-nonfree
    --disable-manpages
    --disable-podpages
    --disable-large-tests
    --enable-libgsm
    --enable-small

  configuration:
    --pkg-config-flags=--static
    --extra-cflags=-fopenmp
    --extra-ldflags=-fopenmp
    --toolchain=hardened
    --disable-debug
    --disable-shared
    --disable-ffplay
    --enable-static
    --enable-gpl
    --enable-version3
    --enable-nonfree
    --disable-manpages
    --disable-podpages
    --disable-large-tests
    --enable-libgsm
```

sizes are as follows...

```shell
-rwxr-xr-x 1 root root 23M Mar  6 11:26 ffmpeg_normal
-rwxr-xr-x 1 root root 17M Mar  6 11:07 ffmpeg_small
```
