### PR TITLE
Update xavs2 from 1.3 to 1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -543,9 +543,9 @@ RUN \
 # bump: xavs2 after ./hashupdate Dockerfile XAVS2 $LATEST
 # bump: xavs2 link "Release" https://github.com/pkuvcl/xavs2/releases/tag/$LATEST
 # bump: xavs2 link "Source diff $CURRENT..$LATEST" https://github.com/pkuvcl/xavs2/compare/v$CURRENT..v$LATEST
-ARG XAVS2_VERSION=1.3
+ARG XAVS2_VERSION=1.4
 ARG XAVS2_URL="https://github.com/pkuvcl/xavs2/archive/refs/tags/$XAVS2_VERSION.tar.gz"
-ARG XAVS2_SHA256=28f9204dc9384336de7c6210cd3317d2d6b94ec23a4d1b6113fcbe7f00d7230b
+ARG XAVS2_SHA256=1e6d731cd64cb2a8940a0a3fd24f9c2ac3bb39357d802432a47bc20bad52c6ce
 # TODO: seems to be issues with asm on musl
 RUN \
   wget -O xavs2.tar.gz "$XAVS2_URL" && \


### PR DESCRIPTION
[Release](https://github.com/pkuvcl/xavs2/releases/tag/1.4)  
[Source diff 1.3..1.4](https://github.com/pkuvcl/xavs2/compare/v1.3..v1.4)  
