### PR TITLE
For now revert "Update svtav1 from 1.1.0 to 1.2.0"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -493,9 +493,9 @@ RUN \
 # bump: svtav1 /SVTAV1_VERSION=([\d.]+)/ https://gitlab.com/AOMediaCodec/SVT-AV1.git|*
 # bump: svtav1 after ./hashupdate Dockerfile SVTAV1 $LATEST
 # bump: svtav1 link "Release notes" https://gitlab.com/AOMediaCodec/SVT-AV1/-/releases/v$LATEST
-ARG SVTAV1_VERSION=1.2.0
+ARG SVTAV1_VERSION=1.1.0
 ARG SVTAV1_URL="https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v$SVTAV1_VERSION/SVT-AV1-v$SVTAV1_VERSION.tar.bz2"
-ARG SVTAV1_SHA256=0f2a060febc652f45d0daddc79d7e09ecb53747fe5feafe32e85a410017e8512
+ARG SVTAV1_SHA256=120dc98d5ccbb4ed326879c6dd4791fa579cdde3dbebf2fad4dd751d8fa7f762
 RUN \
   wget $WGET_OPTS -O svtav1.tar.bz2 "$SVTAV1_URL" && \
   echo "$SVTAV1_SHA256  svtav1.tar.bz2" | sha256sum --status -c - && \


### PR DESCRIPTION
This reverts commit 631df69de742e9508f93ee72c31a5a913ad98d12.

svtav1 test segfaults on arm64 for some reason, have to investigate.