### PR TITLE
Update alpine from 3.16.1 to 3.16.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # bump: alpine /FROM alpine:([\d.]+)/ docker:alpine|^3
 # bump: alpine link "Release notes" https://alpinelinux.org/posts/Alpine-$LATEST-released.html
-FROM alpine:3.16.1 AS builder
+FROM alpine:3.16.2 AS builder
 
 RUN apk add --no-cache \
   coreutils \


### PR DESCRIPTION
[Release notes](https://alpinelinux.org/posts/Alpine-3.16.2-released.html)  
