### PR TITLE
Update libssh from 0.10.3 to 0.10.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -455,9 +455,9 @@ RUN \
 # bump: libssh after ./hashupdate Dockerfile LIBSSH $LATEST
 # bump: libssh link "Source diff $CURRENT..$LATEST" https://gitlab.com/libssh/libssh-mirror/-/compare/libssh-$CURRENT...libssh-$LATEST
 # bump: libssh link "Release notes" https://gitlab.com/libssh/libssh-mirror/-/tags/libssh-$LATEST
-ARG LIBSSH_VERSION=0.10.3
+ARG LIBSSH_VERSION=0.10.4
 ARG LIBSSH_URL="https://gitlab.com/libssh/libssh-mirror/-/archive/libssh-$LIBSSH_VERSION/libssh-mirror-libssh-$LIBSSH_VERSION.tar.gz"
-ARG LIBSSH_SHA256=10b389d18d763877b57ada33f2ddc98a679a0f9b573f5f5c59a981d6d8dc1cf6
+ARG LIBSSH_SHA256=0644d73d4dcb8171c465334dba891b0965311f9ec66b1987805c2882afa0cc58
 # LIBSSH_STATIC=1 is REQUIRED to link statically against libssh.a so add to pkg-config file
 RUN \
   wget $WGET_OPTS -O libssh.tar.gz "$LIBSSH_URL" && \


### PR DESCRIPTION
[Source diff 0.10.3..0.10.4](https://gitlab.com/libssh/libssh-mirror/-/compare/libssh-0.10.3...libssh-0.10.4)  
[Release notes](https://gitlab.com/libssh/libssh-mirror/-/tags/libssh-0.10.4)  
