### PR TITLE
Use multilib build for x265 for 10/12bit access

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Built with the following statically-linked libraries:
 - libvpx
 - libwebp
 - libx264
-- libx265
+- libx265 (multilib with support for 10 and 12 bits)
 - libxavs2
 - libxml2
 - libxvid


### PR DESCRIPTION
Please consider using multilib build of x265 codec to allow for processing of 10+ bit videos.