### PR TITLE
Update libmysofa to 1.3.1 from 1.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -264,9 +264,9 @@ RUN \
 # bump: libmysofa after ./hashupdate Dockerfile LIBMYSOFA $LATEST
 # bump: libmysofa link "Release" https://github.com/hoene/libmysofa/releases/tag/$LATEST
 # bump: libmysofa link "Source diff $CURRENT..$LATEST" https://github.com/hoene/libmysofa/compare/v$CURRENT..v$LATEST
-ARG LIBMYSOFA_VERSION=1.2.1
+ARG LIBMYSOFA_VERSION=1.3.1
 ARG LIBMYSOFA_URL="https://github.com/hoene/libmysofa/archive/refs/tags/v$LIBMYSOFA_VERSION.tar.gz"
-ARG LIBMYSOFA_SHA256=94cb02e488de4dc0860c8d23b29d93d290bb0a004d4aa17e1642985bba158ee9
+ARG LIBMYSOFA_SHA256=a8a8cbf7b0b2508a6932278799b9bf5c63d833d9e7d651aea4622f3bc6b992aa
 RUN \
   wget $WGET_OPTS -O libmysofa.tar.gz "$LIBMYSOFA_URL" && \
   echo "$LIBMYSOFA_SHA256  libmysofa.tar.gz" | sha256sum --status -c - && \


### PR DESCRIPTION
[Release](https://github.com/hoene/libmysofa/releases/tag/1.3.1)  
[Source diff 1.2.1..1.3.1](https://github.com/hoene/libmysofa/compare/v1.2.1..v1.3.1)  
