### PR TITLE
Update x265 to 795122c3140189101b0594a53639dfc451a27d4f from 8c159ba54aaf7f3e815790e7951c2ed285d2e0a7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -668,8 +668,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=8c159ba54aaf7f3e815790e7951c2ed285d2e0a7
-ARG X265_SHA256=e7205f296a34af6179ef4d5a77c672e9fcfbb4bbd0d9fab0be96c92ffab9e336
+ARG X265_VERSION=795122c3140189101b0594a53639dfc451a27d4f
+ARG X265_SHA256=7ea8ca0f7b0e19cc9bf150836e0e78aa4802a5d2afd85a98c6f1a5a87f8b1fb2
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # -w-macro-params-legacy to not log lots of asm warnings
 # https://bitbucket.org/multicoreware/x265_git/issues/559/warnings-when-assembling-with-nasm-215


### PR DESCRIPTION
[Source diff 8c159ba54aaf7f3e815790e7951c2ed285d2e0a7..795122c3140189101b0594a53639dfc451a27d4f](https://bitbucket.org/multicoreware/x265_git/branches/compare/795122c3140189101b0594a53639dfc451a27d4f..8c159ba54aaf7f3e815790e7951c2ed285d2e0a7#diff)  
