### PR TITLE
Update x265 to 40e37bce9a357fb18f70ff0852015983cf90a6d3 from 49ab9e83b0de7394ff785cfd1c2c82eb8f148889

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -668,8 +668,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=49ab9e83b0de7394ff785cfd1c2c82eb8f148889
-ARG X265_SHA256=a54a9ded70063cb69b80bf11955ca3c33947a713439d0ac1a9e14ef6b2922bc9
+ARG X265_VERSION=40e37bce9a357fb18f70ff0852015983cf90a6d3
+ARG X265_SHA256=069749b97ce9f699cafce0ab3accc199d629bfd0128350348c2f119ca39641c6
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # -w-macro-params-legacy to not log lots of asm warnings
 # https://bitbucket.org/multicoreware/x265_git/issues/559/warnings-when-assembling-with-nasm-215


### PR DESCRIPTION
[Source diff 49ab9e83b0de7394ff785cfd1c2c82eb8f148889..40e37bce9a357fb18f70ff0852015983cf90a6d3](https://bitbucket.org/multicoreware/x265_git/branches/compare/40e37bce9a357fb18f70ff0852015983cf90a6d3..49ab9e83b0de7394ff785cfd1c2c82eb8f148889#diff)  
