### PR TITLE
Update x265 to cc25ead66daa466ab27cc14897a48a1b61bcf64e from 40e37bce9a357fb18f70ff0852015983cf90a6d3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -666,8 +666,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=40e37bce9a357fb18f70ff0852015983cf90a6d3
-ARG X265_SHA256=069749b97ce9f699cafce0ab3accc199d629bfd0128350348c2f119ca39641c6
+ARG X265_VERSION=cc25ead66daa466ab27cc14897a48a1b61bcf64e
+ARG X265_SHA256=21666f96f4a10ae60ab10564aa6624aeb433904a4ab5bb6b174cd786f266d9c0
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # -w-macro-params-legacy to not log lots of asm warnings
 # https://bitbucket.org/multicoreware/x265_git/issues/559/warnings-when-assembling-with-nasm-215


### PR DESCRIPTION
[Source diff 40e37bce9a357fb18f70ff0852015983cf90a6d3..cc25ead66daa466ab27cc14897a48a1b61bcf64e](https://bitbucket.org/multicoreware/x265_git/branches/compare/cc25ead66daa466ab27cc14897a48a1b61bcf64e..40e37bce9a357fb18f70ff0852015983cf90a6d3#diff)  
