### PR TITLE
Update x265 to a7ca45961cf3b7aa4fa27e70ef2402a1d7689037 from 4da1198a94028026ce96ba1781d3c7842e74e173

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -666,8 +666,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=4da1198a94028026ce96ba1781d3c7842e74e173
-ARG X265_SHA256=be7f4c382e34eff0841b4466904626f7015e154e346095040e6e046466b03451
+ARG X265_VERSION=a7ca45961cf3b7aa4fa27e70ef2402a1d7689037
+ARG X265_SHA256=5496a1bfedbcb89cfe4ec4f25e8bec76a32d2443c0148aa68e8ba90c98b8e3fc
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # -w-macro-params-legacy to not log lots of asm warnings
 # https://bitbucket.org/multicoreware/x265_git/issues/559/warnings-when-assembling-with-nasm-215


### PR DESCRIPTION
[Source diff 4da1198a94028026ce96ba1781d3c7842e74e173..a7ca45961cf3b7aa4fa27e70ef2402a1d7689037](https://bitbucket.org/multicoreware/x265_git/branches/compare/a7ca45961cf3b7aa4fa27e70ef2402a1d7689037..4da1198a94028026ce96ba1781d3c7842e74e173#diff)  
