### PR TITLE
Update x265 to 82225f9a56f96f7d252724249b5ba056feac858d from a7cd02c18aa4591f46119b675c64817f165ed9a3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -666,8 +666,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=a7cd02c18aa4591f46119b675c64817f165ed9a3
-ARG X265_SHA256=8965e03caa7f085a00fa40531a6c406b51c01efea645ad3cbb5f09ac5f43139c
+ARG X265_VERSION=82225f9a56f96f7d252724249b5ba056feac858d
+ARG X265_SHA256=44a4831b9618be604a425ffe5e4b7e26b35d31efccf5813a46e62cffaa51cba7
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # -w-macro-params-legacy to not log lots of asm warnings
 # https://bitbucket.org/multicoreware/x265_git/issues/559/warnings-when-assembling-with-nasm-215


### PR DESCRIPTION
[Source diff a7cd02c18aa4591f46119b675c64817f165ed9a3..82225f9a56f96f7d252724249b5ba056feac858d](https://bitbucket.org/multicoreware/x265_git/branches/compare/82225f9a56f96f7d252724249b5ba056feac858d..a7cd02c18aa4591f46119b675c64817f165ed9a3#diff)  
