### PR TITLE
Update x265 to 7f247b623f12f117c6d6fa8e282996eda9e0ccf7 from da97f4fc4728a5fea7f92ee8fdc3aa3a24b94f3d

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -671,8 +671,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=da97f4fc4728a5fea7f92ee8fdc3aa3a24b94f3d
-ARG X265_SHA256=8f6fa6543a3877caf947542533b24fff26ab373c99d78ef4d560341b6d05d48c
+ARG X265_VERSION=7f247b623f12f117c6d6fa8e282996eda9e0ccf7
+ARG X265_SHA256=3423dea2293218a793006aacb86140aa4acf60f957d70e6025170f59263af19c
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # -w-macro-params-legacy to not log lots of asm warnings
 # https://bitbucket.org/multicoreware/x265_git/issues/559/warnings-when-assembling-with-nasm-215


### PR DESCRIPTION
[Source diff da97f4fc4728a5fea7f92ee8fdc3aa3a24b94f3d..7f247b623f12f117c6d6fa8e282996eda9e0ccf7](https://bitbucket.org/multicoreware/x265_git/branches/compare/7f247b623f12f117c6d6fa8e282996eda9e0ccf7..da97f4fc4728a5fea7f92ee8fdc3aa3a24b94f3d#diff)  
