### PR TITLE
Update x265 to 3dae0c3cce76026e6f04672ca812fb255b067219 from 753305affb093ae15d5e4b333125267b16258c21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -672,8 +672,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=753305affb093ae15d5e4b333125267b16258c21
-ARG X265_SHA256=19fd63d3039d7662d2a75fdaf4c29c4a31ea65a9d7f44fe2da88feda59e7cb8b
+ARG X265_VERSION=3dae0c3cce76026e6f04672ca812fb255b067219
+ARG X265_SHA256=fcd9c3ec054d427daef688534d94bfb367b8b62bb3ea99f09295c034977e9c29
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # -w-macro-params-legacy to not log lots of asm warnings
 # https://bitbucket.org/multicoreware/x265_git/issues/559/warnings-when-assembling-with-nasm-215


### PR DESCRIPTION
[Source diff 753305affb093ae15d5e4b333125267b16258c21..3dae0c3cce76026e6f04672ca812fb255b067219](https://bitbucket.org/multicoreware/x265_git/branches/compare/3dae0c3cce76026e6f04672ca812fb255b067219..753305affb093ae15d5e4b333125267b16258c21#diff)  
