### PR TITLE
Update x265 to 8f18e3ad32684eee95e885e718655f93951128c3 from 34532bda12a3a3141880582aa186a59cd4538ae6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -685,8 +685,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=34532bda12a3a3141880582aa186a59cd4538ae6
-ARG X265_SHA256=c409bb4cf2e93b6785ab8da7ba49e10a8c46f3ca743d407fb6d0948dea37c788
+ARG X265_VERSION=8f18e3ad32684eee95e885e718655f93951128c3
+ARG X265_SHA256=f657b2b0384fe737a65e02fa62057f59612aec7d2f694ab7449d6ada61bc4654
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # -w-macro-params-legacy to not log lots of asm warnings
 # https://bitbucket.org/multicoreware/x265_git/issues/559/warnings-when-assembling-with-nasm-215


### PR DESCRIPTION
[Source diff 34532bda12a3a3141880582aa186a59cd4538ae6..8f18e3ad32684eee95e885e718655f93951128c3](https://bitbucket.org/multicoreware/x265_git/branches/compare/8f18e3ad32684eee95e885e718655f93951128c3..34532bda12a3a3141880582aa186a59cd4538ae6#diff)  
