### PR TITLE
Update x265 to 59ff5e7b4840b3aac91fbc514a4c86a8722ce5e1 from 8f18e3ad32684eee95e885e718655f93951128c3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -685,8 +685,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=8f18e3ad32684eee95e885e718655f93951128c3
-ARG X265_SHA256=f657b2b0384fe737a65e02fa62057f59612aec7d2f694ab7449d6ada61bc4654
+ARG X265_VERSION=59ff5e7b4840b3aac91fbc514a4c86a8722ce5e1
+ARG X265_SHA256=08f3b9542e2e1c03d23ade458416a656feae9523c4948c1e3aa4c45294f9ead7
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # -w-macro-params-legacy to not log lots of asm warnings
 # https://bitbucket.org/multicoreware/x265_git/issues/559/warnings-when-assembling-with-nasm-215


### PR DESCRIPTION
[Source diff 8f18e3ad32684eee95e885e718655f93951128c3..59ff5e7b4840b3aac91fbc514a4c86a8722ce5e1](https://bitbucket.org/multicoreware/x265_git/branches/compare/59ff5e7b4840b3aac91fbc514a4c86a8722ce5e1..8f18e3ad32684eee95e885e718655f93951128c3#diff)  
