### PR TITLE
Revert "Update x265 to a55e7566a5bef8b4d36d8fed50d596ebcb47e34e from a05d9f5f7f4bea74792782720b6a4d028e99089e"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -685,8 +685,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=a55e7566a5bef8b4d36d8fed50d596ebcb47e34e
-ARG X265_SHA256=351fa81c9eb6ee3a37131fef835e9fc170d099312d17282fa61b2ceb5571816f
+ARG X265_VERSION=a05d9f5f7f4bea74792782720b6a4d028e99089e
+ARG X265_SHA256=a0acca450ee540c08d1397c04847debaebfe26450ea1cc63804873200c17d579
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # -w-macro-params-legacy to not log lots of asm warnings
 # https://bitbucket.org/multicoreware/x265_git/issues/559/warnings-when-assembling-with-nasm-215


### PR DESCRIPTION
Reverts wader/static-ffmpeg#333

static PIE link seems broken, commented upstream https://bitbucket.org/multicoreware/x265_git/pull-requests/15#chg-source/common/aarch64/asm.S