### PR TITLE
Update x265 to 343ac2692c771b4539fe41d12408fd75b4289e7e from a05d9f5f7f4bea74792782720b6a4d028e99089e

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -685,8 +685,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=a05d9f5f7f4bea74792782720b6a4d028e99089e
-ARG X265_SHA256=a0acca450ee540c08d1397c04847debaebfe26450ea1cc63804873200c17d579
+ARG X265_VERSION=343ac2692c771b4539fe41d12408fd75b4289e7e
+ARG X265_SHA256=fd8dd7ae90f86cdc4e73e1854526832765aa4945ff354dff5137c24b3b5b9a00
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # -w-macro-params-legacy to not log lots of asm warnings
 # https://bitbucket.org/multicoreware/x265_git/issues/559/warnings-when-assembling-with-nasm-215


### PR DESCRIPTION
[Source diff a05d9f5f7f4bea74792782720b6a4d028e99089e..343ac2692c771b4539fe41d12408fd75b4289e7e](https://bitbucket.org/multicoreware/x265_git/branches/compare/343ac2692c771b4539fe41d12408fd75b4289e7e..a05d9f5f7f4bea74792782720b6a4d028e99089e#diff)  
