### PR TITLE
Update libmysofa to 1.3.2 from 1.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -284,9 +284,9 @@ RUN \
 # bump: libmysofa after ./hashupdate Dockerfile LIBMYSOFA $LATEST
 # bump: libmysofa link "Release" https://github.com/hoene/libmysofa/releases/tag/v$LATEST
 # bump: libmysofa link "Source diff $CURRENT..$LATEST" https://github.com/hoene/libmysofa/compare/v$CURRENT..v$LATEST
-ARG LIBMYSOFA_VERSION=1.3.1
+ARG LIBMYSOFA_VERSION=1.3.2
 ARG LIBMYSOFA_URL="https://github.com/hoene/libmysofa/archive/refs/tags/v$LIBMYSOFA_VERSION.tar.gz"
-ARG LIBMYSOFA_SHA256=a8a8cbf7b0b2508a6932278799b9bf5c63d833d9e7d651aea4622f3bc6b992aa
+ARG LIBMYSOFA_SHA256=6c5224562895977e87698a64cb7031361803d136057bba35ed4979b69ab4ba76
 RUN \
   wget $WGET_OPTS -O libmysofa.tar.gz "$LIBMYSOFA_URL" && \
   echo "$LIBMYSOFA_SHA256  libmysofa.tar.gz" | sha256sum --status -c - && \


### PR DESCRIPTION
[Release](https://github.com/hoene/libmysofa/releases/tag/v1.3.2)  
[Source diff 1.3.1..1.3.2](https://github.com/hoene/libmysofa/compare/v1.3.1..v1.3.2)  
