### PR TITLE
Update x265 to ce8642f22123f0b8cf105c88fc1e8af9888bd345 from 8ee01d45b05cdbc9da89b884815257807a514bc8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -688,8 +688,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=8ee01d45b05cdbc9da89b884815257807a514bc8
-ARG X265_SHA256=d0fa8da2fbebc6085b7b37e5af207e3d5b2f1c6b0e974b047f3048a0bd292658
+ARG X265_VERSION=ce8642f22123f0b8cf105c88fc1e8af9888bd345
+ARG X265_SHA256=a794eb4c0c086f646d033d1a064832313845c18ea7218e0b412b3cc615bae4b7
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff 8ee01d45b05cdbc9da89b884815257807a514bc8..ce8642f22123f0b8cf105c88fc1e8af9888bd345](https://bitbucket.org/multicoreware/x265_git/branches/compare/ce8642f22123f0b8cf105c88fc1e8af9888bd345..8ee01d45b05cdbc9da89b884815257807a514bc8#diff)  
