### PR TITLE
Update libssh to 0.10.6 from 0.10.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -487,9 +487,9 @@ RUN \
 # bump: libssh after ./hashupdate Dockerfile LIBSSH $LATEST
 # bump: libssh link "Source diff $CURRENT..$LATEST" https://gitlab.com/libssh/libssh-mirror/-/compare/libssh-$CURRENT...libssh-$LATEST
 # bump: libssh link "Release notes" https://gitlab.com/libssh/libssh-mirror/-/tags/libssh-$LATEST
-ARG LIBSSH_VERSION=0.10.5
+ARG LIBSSH_VERSION=0.10.6
 ARG LIBSSH_URL="https://gitlab.com/libssh/libssh-mirror/-/archive/libssh-$LIBSSH_VERSION/libssh-mirror-libssh-$LIBSSH_VERSION.tar.gz"
-ARG LIBSSH_SHA256=6cc403619d35b3ebdb42e712e70240b54ba51cd9bb88214e9d16ed19ef6ab103
+ARG LIBSSH_SHA256=3a29ee78cbe0305459fc8a337b3b0dc3335b7724299dc69ab2657607746a1d82
 # LIBSSH_STATIC=1 is REQUIRED to link statically against libssh.a so add to pkg-config file
 # make does not -j as it seems to be shaky, libssh.a used before created
 RUN wget $WGET_OPTS -O libssh.tar.gz "$LIBSSH_URL"


### PR DESCRIPTION
[Source diff 0.10.5..0.10.6](https://gitlab.com/libssh/libssh-mirror/-/compare/libssh-0.10.5...libssh-0.10.6)  
[Release notes](https://gitlab.com/libssh/libssh-mirror/-/tags/libssh-0.10.6)  
