### PR TITLE
Update rav1e to 0.7.0 from 0.6.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -386,9 +386,9 @@ RUN \
 # bump: rav1e /RAV1E_VERSION=([\d.]+)/ https://github.com/xiph/rav1e.git|/\d+\./|*
 # bump: rav1e after ./hashupdate Dockerfile RAV1E $LATEST
 # bump: rav1e link "Release notes" https://github.com/xiph/rav1e/releases/tag/v$LATEST
-ARG RAV1E_VERSION=0.6.6
+ARG RAV1E_VERSION=0.7.0
 ARG RAV1E_URL="https://github.com/xiph/rav1e/archive/v$RAV1E_VERSION.tar.gz"
-ARG RAV1E_SHA256=723696e93acbe03666213fbc559044f3cae5b8b888b2ddae667402403cff51e5
+ARG RAV1E_SHA256=dd6c4b771d985f547787383f5d77bc124ac406d574a308a897da9642410c1855
 RUN wget $WGET_OPTS -O rav1e.tar.gz "$RAV1E_URL"
 RUN echo "$RAV1E_SHA256  rav1e.tar.gz" | sha256sum --status -c -
 RUN \


### PR DESCRIPTION
[Release notes](https://github.com/xiph/rav1e/releases/tag/v0.7.0)  
