### PR TITLE
Update opus to 1.5.1 from 1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -341,9 +341,9 @@ RUN \
 # bump: opus after ./hashupdate Dockerfile OPUS $LATEST
 # bump: opus link "Release notes" https://github.com/xiph/opus/releases/tag/v$LATEST
 # bump: opus link "Source diff $CURRENT..$LATEST" https://github.com/xiph/opus/compare/v$CURRENT..v$LATEST
-ARG OPUS_VERSION=1.4
-ARG OPUS_URL="https://github.com/xiph/opus/releases/download/v$OPUS_VERSION/opus-$OPUS_VERSION.tar.gz"
-ARG OPUS_SHA256=c9b32b4253be5ae63d1ff16eea06b94b5f0f2951b7a02aceef58e3a3ce49c51f
+ARG OPUS_VERSION=1.5.1
+ARG OPUS_URL="https://downloads.xiph.org/releases/opus/opus-$OPUS_VERSION.tar.gz"
+ARG OPUS_SHA256=b84610959b8d417b611aa12a22565e0a3732097c6389d19098d844543e340f85
 RUN wget $WGET_OPTS -O opus.tar.gz "$OPUS_URL"
 RUN echo "$OPUS_SHA256  opus.tar.gz" | sha256sum --status -c -
 RUN \


### PR DESCRIPTION
[Release notes](https://github.com/xiph/opus/releases/tag/v1.5.1)  
[Source diff 1.4..1.5.1](https://github.com/xiph/opus/compare/v1.4..v1.5.1)  
