### PR TITLE
Update x265 to 5a6d85d768699c36fe810c40be89db82033f6743 from 3cf6c1e53037eb9e198860365712e1bafb22f7c6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -684,8 +684,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=3cf6c1e53037eb9e198860365712e1bafb22f7c6
-ARG X265_SHA256=b723e0b9362783490246ec66b520e8f4324dcd0b1b34aef546829d54f0797755
+ARG X265_VERSION=5a6d85d768699c36fe810c40be89db82033f6743
+ARG X265_SHA256=31b8c8e8e64ba848c4e6ecb3c7ad29bef774de10a91b960fb04e315281bd9084
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff 3cf6c1e53037eb9e198860365712e1bafb22f7c6..5a6d85d768699c36fe810c40be89db82033f6743](https://bitbucket.org/multicoreware/x265_git/branches/compare/5a6d85d768699c36fe810c40be89db82033f6743..3cf6c1e53037eb9e198860365712e1bafb22f7c6#diff)  
