### PR TITLE
Update x265 to e112940bba1b850667dca016a499148d4ead7d6b from 7f67d23c11b814a2410e0bc212d30aee197064e9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -684,8 +684,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=7f67d23c11b814a2410e0bc212d30aee197064e9
-ARG X265_SHA256=4ab1cd061c2b423fb1781f27c38620eff0a7603d385c49022820223813dcb95e
+ARG X265_VERSION=e112940bba1b850667dca016a499148d4ead7d6b
+ARG X265_SHA256=f137263578e2e29574c70e3af91c77505bdc274cf1af94d6441a7f49248a5c95
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff 7f67d23c11b814a2410e0bc212d30aee197064e9..e112940bba1b850667dca016a499148d4ead7d6b](https://bitbucket.org/multicoreware/x265_git/branches/compare/e112940bba1b850667dca016a499148d4ead7d6b..7f67d23c11b814a2410e0bc212d30aee197064e9#diff)  
