### PR TITLE
Update x265 to 5319991ff3a31df61ff2c470ef0d890452c7d583 from dd1ef69b25ec26cc80be0fc8d9afeeef6563762b

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -719,8 +719,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=dd1ef69b25ec26cc80be0fc8d9afeeef6563762b
-ARG X265_SHA256=8cef03006bedf7691e539d8ccc161fb4f78ed08b9e154c3d53c499f34494bd77
+ARG X265_VERSION=5319991ff3a31df61ff2c470ef0d890452c7d583
+ARG X265_SHA256=3ef6f70052f3e84ef590d25a0d7115bc1a965b11c7df4fd2503231c03d035e4e
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff dd1ef69b25ec26cc80be0fc8d9afeeef6563762b..5319991ff3a31df61ff2c470ef0d890452c7d583](https://bitbucket.org/multicoreware/x265_git/branches/compare/5319991ff3a31df61ff2c470ef0d890452c7d583..dd1ef69b25ec26cc80be0fc8d9afeeef6563762b#diff)  
