### PR TITLE
Update x265 to 53afbf5f5d6f8c081e3c56a9884eecf3e6e583bb from 5319991ff3a31df61ff2c470ef0d890452c7d583

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -719,8 +719,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=5319991ff3a31df61ff2c470ef0d890452c7d583
-ARG X265_SHA256=3ef6f70052f3e84ef590d25a0d7115bc1a965b11c7df4fd2503231c03d035e4e
+ARG X265_VERSION=53afbf5f5d6f8c081e3c56a9884eecf3e6e583bb
+ARG X265_SHA256=17a8a79de1f1f3a322b887fe80b9e88abb986e9e68cc0329a8de9281cf84d03f
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff 5319991ff3a31df61ff2c470ef0d890452c7d583..53afbf5f5d6f8c081e3c56a9884eecf3e6e583bb](https://bitbucket.org/multicoreware/x265_git/branches/compare/53afbf5f5d6f8c081e3c56a9884eecf3e6e583bb..5319991ff3a31df61ff2c470ef0d890452c7d583#diff)  
