### PR TITLE
Update x265 to f3c5fbaffaf54b5f79aa8983d59f1b0232d5eccf from 05d6a17db1d52c45c3ad7db240401dd1b18480bb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -714,8 +714,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=05d6a17db1d52c45c3ad7db240401dd1b18480bb
-ARG X265_SHA256=59e8186a34c0daf7999f29418fcae60bb9044cc1b0ee53066f2d7377e1e4603f
+ARG X265_VERSION=f3c5fbaffaf54b5f79aa8983d59f1b0232d5eccf
+ARG X265_SHA256=af5e5631c9e3feb21cb305c7d9fa1e4bcf7659a8c86a07f770b84c1d96e6f740
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff 05d6a17db1d52c45c3ad7db240401dd1b18480bb..f3c5fbaffaf54b5f79aa8983d59f1b0232d5eccf](https://bitbucket.org/multicoreware/x265_git/branches/compare/f3c5fbaffaf54b5f79aa8983d59f1b0232d5eccf..05d6a17db1d52c45c3ad7db240401dd1b18480bb#diff)  
