### PR TITLE
Make alpine version configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-# bump: alpine /FROM alpine:([\d.]+)/ docker:alpine|^3
+# bump: alpine /ALPINE_VERSION=alpine:([\d.]+)/ docker:alpine|^3
 # bump: alpine link "Release notes" https://alpinelinux.org/posts/Alpine-$LATEST-released.html
-FROM alpine:3.20.0 AS builder
+ARG ALPINE_VERSION=alpine:3.20.0
+FROM $ALPINE_VERSION AS builder
 
 RUN apk add --no-cache \
   coreutils \


### PR DESCRIPTION
I need to install certificates (due TLS inspection) to access the internet. Now I use a custom `alpine` base container (containing ssl certifcates) which I use to build `static-ffmpeg`. 