### PR TITLE
Remove hyphen from cd to support ffmpeg snapshot builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1045,7 +1045,7 @@ ARG ENABLE_FDKAAC=
 RUN \
   wget $WGET_OPTS -O ffmpeg.tar.bz2 "$FFMPEG_URL" && \
   echo "$FFMPEG_SHA256  ffmpeg.tar.bz2" | sha256sum -c - && \
-  tar $TAR_OPTS ffmpeg.tar.bz2 && cd ffmpeg-* && \
+  tar $TAR_OPTS ffmpeg.tar.bz2 && cd ffmpeg* && \
   FDKAAC_FLAGS=$(if [[ -n "$ENABLE_FDKAAC" ]] ;then echo " --enable-libfdk-aac --enable-nonfree " ;else echo ""; fi) && \
   sed -i 's/add_ldexeflags -fPIE -pie/add_ldexeflags -fPIE -static-pie/' configure && \
   ./configure \


### PR DESCRIPTION
I want to build a ffmpeg snapshot version which I downloaded from https://www.ffmpeg.org/releases/ffmpeg-snapshot.tar.bz2

When I build this version (with a custom build argument), I get this error: 

```
cd: ffmpeg-*: No such file or director
```

This error occurs because the ffmpeg folder in this archive does not contain a version. 