### PR TITLE
Cuda compile ffmpeg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1026,6 +1026,18 @@ RUN \
   sed -i 's/-ljxl_cms/-ljxl_cms -lstdc++ /' /usr/local/lib/pkgconfig/libjxl_cms.pc && \
   sed -i 's/-ljxl_threads/-ljxl_threads -lstdc++ /' /usr/local/lib/pkgconfig/libjxl_threads.pc
 
+# bump: nv-codec-headers /NV_CODEC_HEADERS_VERSION=([\d.]+)/ https://github.com/FFmpeg/nv-codec-headers.git|*
+# bump: nv-codec-headers after ./hashupdate Dockerfile NV_CODEC_HEADERS $LATEST
+# bump: nv-codec-headers link "Source diff $CURRENT..$LATEST" https://github.com/FFmpeg/nv-codec-headers/compare/v$CURRENT..v$LATEST
+ARG NV_CODEC_HEADERS_VERSION=12.2.72.0
+ARG NV_CODEC_HEADERS_URL="https://github.com/FFmpeg/nv-codec-headers/archive/n$NV_CODEC_HEADERS_VERSION.tar.gz"
+ARG NV_CODEC_HEADERS_SHA256=dbeaec433d93b850714760282f1d0992b1254fc3b5a6cb7d76fc1340a1e47563
+RUN \
+  wget $WGET_OPTS -O nv-codec-headers.tar.gz "$NV_CODEC_HEADERS_URL" && \
+  echo "$NV_CODEC_HEADERS_SHA256  nv-codec-headers.tar.gz" | sha256sum -c - && \
+  tar $TAR_OPTS nv-codec-headers.tar.gz && cd nv-codec-headers-* && \
+  make -j$(nproc) install
+
 # bump: ffmpeg /FFMPEG_VERSION=([\d.]+)/ https://github.com/FFmpeg/FFmpeg.git|*
 # bump: ffmpeg after ./hashupdate Dockerfile FFMPEG $LATEST
 # bump: ffmpeg link "Changelog" https://github.com/FFmpeg/FFmpeg/blob/n$LATEST/Changelog
@@ -1043,6 +1055,7 @@ ARG ENABLE_FDKAAC=
 # ldfalgs -Wl,--allow-multiple-definition is a workaround for linking with multiple rust staticlib to
 # not cause collision in toolchain symbols, see comment in checkdupsym script for details.
 RUN \
+  set -ex && \
   wget $WGET_OPTS -O ffmpeg.tar.bz2 "$FFMPEG_URL" && \
   echo "$FFMPEG_SHA256  ffmpeg.tar.bz2" | sha256sum -c - && \
   tar $TAR_OPTS ffmpeg.tar.bz2 && cd ffmpeg* && \
@@ -1050,8 +1063,8 @@ RUN \
   sed -i 's/add_ldexeflags -fPIE -pie/add_ldexeflags -fPIE -static-pie/' configure && \
   ./configure \
   --pkg-config-flags="--static" \
-  --extra-cflags="-fopenmp" \
-  --extra-ldflags="-fopenmp -Wl,--allow-multiple-definition -Wl,-z,stack-size=2097152" \
+  --extra-cflags="-fopenmp -I/usr/local/cuda/include" \
+  --extra-ldflags="-fopenmp -Wl,--allow-multiple-definition -Wl,-z,stack-size=2097152 -L/usr/local/cuda/lib64" \
   --toolchain=hardened \
   --disable-debug \
   --disable-shared \
@@ -1114,6 +1127,9 @@ RUN \
   --enable-libzimg \
   --enable-openssl \
   --enable-libjxl \
+  --enable-cuda-nvcc \
+  --enable-libnpp \
+  --enable-nonfree \
   || (cat ffbuild/config.log ; false) \
   && make -j$(nproc) install
 


### PR DESCRIPTION
Related #480 

---

Hey @wader 👋 

This seems this really out of my league. I don't know what to do to even get this to compile right now, but I thought I'll just add the draft here for now anyway.

**Issue 1**

The [install guide](https://docs.nvidia.com/video-technologies/video-codec-sdk/12.0/ffmpeg-with-nvidia-gpu/index.html#compiling-for-linux) shows to install the following packages needed:

```shell
sudo apt-get install build-essential yasm cmake libtool libc6 libc6-dev unzip wget libnuma1 libnuma-dev
```

I'm not sure what the `libc6 libc6-devlibnuma1 libnuma-dev` equivalents are on Alpine, but that's my first roadblock.

**Issue 2**

Looking at some other FFmpeg Dockerfiles for CUDA support, I see a lot using either [nvidia/cuda (ubuntu)](https://github.com/jrottenberg/ffmpeg/blob/main/docker-images/7.0/nvidia2204/Dockerfile) or normal [ubuntu](https://github.com/linuxserver/docker-ffmpeg/blob/master/Dockerfile) as base image. Almost makes me think it is either not easy, or not possible to compile for Alpine (?).

**Issue 3**

One of the other things in the installation guide, is to configure with `--enable-nonfree`. Now I saw that for `libfdk_aac` this was denoted in the README that you should build the image yourself, and it also has the `--enable-nonfree` flag. Would this pose an issue here as well?


