### PR TITLE
Enable avx512 during svt-av1 compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -690,6 +690,7 @@ RUN \
     -DCMAKE_VERBOSE_MAKEFILE=ON \
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DBUILD_SHARED_LIBS=OFF \
+    -DENABLE_AVX512=ON \
     -DCMAKE_BUILD_TYPE=Release \
     .. && \
   make -j$(nproc) install


### PR DESCRIPTION
This change should allow for usage of AVX512 when using SVT-AV1 codec. This is to address #483 