### PR TITLE
Update x265 to 0dfbe6dee33263d2bc8a12a06b7e3925f276560d from ad1a30a8a69d5bbc0096da7aafc9da21c599cb01

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -877,8 +877,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=ad1a30a8a69d5bbc0096da7aafc9da21c599cb01
-ARG X265_SHA256=77c9818230c6e66df85d0892710956a68c81f9d2145550fb4ca60decdf7553a9
+ARG X265_VERSION=0dfbe6dee33263d2bc8a12a06b7e3925f276560d
+ARG X265_SHA256=3acef49f87967e9a257498c13a2d69c5f6d14472eebe4918eb85a5ebbe2f990e
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff ad1a30a8a69d5bbc0096da7aafc9da21c599cb01..0dfbe6dee33263d2bc8a12a06b7e3925f276560d](https://bitbucket.org/multicoreware/x265_git/branches/compare/0dfbe6dee33263d2bc8a12a06b7e3925f276560d..ad1a30a8a69d5bbc0096da7aafc9da21c599cb01#diff)  
