### PR TITLE
Update libssh to 0.11.0 from 0.10.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -638,9 +638,9 @@ RUN \
 # bump: libssh after ./hashupdate Dockerfile LIBSSH $LATEST
 # bump: libssh link "Source diff $CURRENT..$LATEST" https://gitlab.com/libssh/libssh-mirror/-/compare/libssh-$CURRENT...libssh-$LATEST
 # bump: libssh link "Release notes" https://gitlab.com/libssh/libssh-mirror/-/tags/libssh-$LATEST
-ARG LIBSSH_VERSION=0.10.6
+ARG LIBSSH_VERSION=0.11.0
 ARG LIBSSH_URL="https://gitlab.com/libssh/libssh-mirror/-/archive/libssh-$LIBSSH_VERSION/libssh-mirror-libssh-$LIBSSH_VERSION.tar.gz"
-ARG LIBSSH_SHA256=3a29ee78cbe0305459fc8a337b3b0dc3335b7724299dc69ab2657607746a1d82
+ARG LIBSSH_SHA256=f4b4d7e9352702968f6f42af4c88a02359384db26f275faaeef2aaf5dd64756f
 # LIBSSH_STATIC=1 is REQUIRED to link statically against libssh.a so add to pkg-config file
 # make does not -j as it seems to be shaky, libssh.a used before created
 RUN \


### PR DESCRIPTION
[Source diff 0.10.6..0.11.0](https://gitlab.com/libssh/libssh-mirror/-/compare/libssh-0.10.6...libssh-0.11.0)  
[Release notes](https://gitlab.com/libssh/libssh-mirror/-/tags/libssh-0.11.0)  
