### PR TITLE
Update x265 to 1cb70f6b44247a069163ab79c213620bfc3b1bf6 from 7afb5179dd9324c9af18deefc96c781cf0710c1f

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -877,8 +877,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=7afb5179dd9324c9af18deefc96c781cf0710c1f
-ARG X265_SHA256=ad2bfbe5e54aa490435c1aa35444cd95afa994d2da88e243673df8379219ebea
+ARG X265_VERSION=1cb70f6b44247a069163ab79c213620bfc3b1bf6
+ARG X265_SHA256=aca067eab5b066ffaacd3803452c85968ce1d26e89700eafd36cda7953ba7275
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff 7afb5179dd9324c9af18deefc96c781cf0710c1f..1cb70f6b44247a069163ab79c213620bfc3b1bf6](https://bitbucket.org/multicoreware/x265_git/branches/compare/1cb70f6b44247a069163ab79c213620bfc3b1bf6..7afb5179dd9324c9af18deefc96c781cf0710c1f#diff)  
