### PR TITLE
Update x265 to 0be061d74a5f1bc4286358af9538a5053ada772e from a7c56d4d44c47f92bf2a0424ef4949e5382fb1b7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -877,8 +877,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=a7c56d4d44c47f92bf2a0424ef4949e5382fb1b7
-ARG X265_SHA256=ea0b3c7c677de2067ff8c9204db0b1ba77922f34d4cf8aa421e48dd8a21d7f05
+ARG X265_VERSION=0be061d74a5f1bc4286358af9538a5053ada772e
+ARG X265_SHA256=aa3d1ef7d304144f737d5add4ba2bb7bbc7abefe266a1020930df71dc55929c1
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff a7c56d4d44c47f92bf2a0424ef4949e5382fb1b7..0be061d74a5f1bc4286358af9538a5053ada772e](https://bitbucket.org/multicoreware/x265_git/branches/compare/0be061d74a5f1bc4286358af9538a5053ada772e..a7c56d4d44c47f92bf2a0424ef4949e5382fb1b7#diff)  
