### PR TITLE
Update x265 to c1686da954da90a84d3a6bbecf567c3cfa0269e8 from 0be061d74a5f1bc4286358af9538a5053ada772e

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -877,8 +877,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=0be061d74a5f1bc4286358af9538a5053ada772e
-ARG X265_SHA256=aa3d1ef7d304144f737d5add4ba2bb7bbc7abefe266a1020930df71dc55929c1
+ARG X265_VERSION=c1686da954da90a84d3a6bbecf567c3cfa0269e8
+ARG X265_SHA256=65c64f25a8ead0222d3a0c88800d4d0c309847e0730c6004c6239e05aaa71dae
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff 0be061d74a5f1bc4286358af9538a5053ada772e..c1686da954da90a84d3a6bbecf567c3cfa0269e8](https://bitbucket.org/multicoreware/x265_git/branches/compare/c1686da954da90a84d3a6bbecf567c3cfa0269e8..0be061d74a5f1bc4286358af9538a5053ada772e#diff)  
