### PR TITLE
Update librsvg to 2.58.94 from 2.58.93

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,9 +167,9 @@ RUN \
 # bump: librsvg /LIBRSVG_VERSION=([\d.]+)/ https://gitlab.gnome.org/GNOME/librsvg.git|^2
 # bump: librsvg after ./hashupdate Dockerfile LIBRSVG $LATEST
 # bump: librsvg link "NEWS" https://gitlab.gnome.org/GNOME/librsvg/-/blob/master/NEWS
-ARG LIBRSVG_VERSION=2.58.93
+ARG LIBRSVG_VERSION=2.58.94
 ARG LIBRSVG_URL="https://download.gnome.org/sources/librsvg/2.58/librsvg-$LIBRSVG_VERSION.tar.xz"
-ARG LIBRSVG_SHA256=f116eaf8196fc8261b0bbbdf996a4fe1bc97dc25664f953b328194d049a0dada
+ARG LIBRSVG_SHA256=05adf6dc58b3cfb319c2efb02b2bbdff5c75ca47cc941d48098839f20496abed
 RUN \
   wget $WGET_OPTS -O librsvg.tar.xz "$LIBRSVG_URL" && \
   echo "$LIBRSVG_SHA256  librsvg.tar.xz" | sha256sum --status -c - && \


### PR DESCRIPTION
[NEWS](https://gitlab.gnome.org/GNOME/librsvg/-/blob/master/NEWS)  
