### PR TITLE
Update x265 to 973bf1ac711c3d945018eebd35575b4940054906 from f6735953b90e4ff74849e20156a520f5bfd410fc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -877,8 +877,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=f6735953b90e4ff74849e20156a520f5bfd410fc
-ARG X265_SHA256=ae668028a9c10b4438ed5cc4257c97c11b3dd601050f08c7b1f489e99850ac61
+ARG X265_VERSION=973bf1ac711c3d945018eebd35575b4940054906
+ARG X265_SHA256=57293476deec3ea2933c9e5d3ed4256abc4ed7017d5c99151671c83ad09d93be
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff f6735953b90e4ff74849e20156a520f5bfd410fc..973bf1ac711c3d945018eebd35575b4940054906](https://bitbucket.org/multicoreware/x265_git/branches/compare/973bf1ac711c3d945018eebd35575b4940054906..f6735953b90e4ff74849e20156a520f5bfd410fc#diff)  
