### PR TITLE
Update x265 to a009ec07721b1e7fcf5289619a3cd5dd6b67a546 from 1a826a1d2b19c74145c70c781364f0cd926862e1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -878,8 +878,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=1a826a1d2b19c74145c70c781364f0cd926862e1
-ARG X265_SHA256=b80aca10db35b1db2c5b90c07ed231f16c497d92329bdfc36d442c32b48f8e9c
+ARG X265_VERSION=a009ec07721b1e7fcf5289619a3cd5dd6b67a546
+ARG X265_SHA256=833cc28f7fb472e770f06f553ea351b3c190e171e364456f0cd0106c4e5f8ab0
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff 1a826a1d2b19c74145c70c781364f0cd926862e1..a009ec07721b1e7fcf5289619a3cd5dd6b67a546](https://bitbucket.org/multicoreware/x265_git/branches/compare/a009ec07721b1e7fcf5289619a3cd5dd6b67a546..1a826a1d2b19c74145c70c781364f0cd926862e1#diff)  
