### PR TITLE
Update librsvg to 2.59.1 from 2.59.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -168,9 +168,9 @@ RUN \
 # bump: librsvg /LIBRSVG_VERSION=([\d.]+)/ https://gitlab.gnome.org/GNOME/librsvg.git|^2
 # bump: librsvg after ./hashupdate Dockerfile LIBRSVG $LATEST
 # bump: librsvg link "NEWS" https://gitlab.gnome.org/GNOME/librsvg/-/blob/master/NEWS
-ARG LIBRSVG_VERSION=2.59.0
+ARG LIBRSVG_VERSION=2.59.1
 ARG LIBRSVG_URL="https://download.gnome.org/sources/librsvg/2.59/librsvg-$LIBRSVG_VERSION.tar.xz"
-ARG LIBRSVG_SHA256=370d6ada5cf0de91ceb70d849ed069523ce5de2b33b4c7e86bc640673ad65483
+ARG LIBRSVG_SHA256=6116267c7ddabfd4daaf1c341326da0a773139a7223e885ae40ee09bd6986ef6
 RUN \
   wget $WGET_OPTS -O librsvg.tar.xz "$LIBRSVG_URL" && \
   echo "$LIBRSVG_SHA256  librsvg.tar.xz" | sha256sum --status -c - && \


### PR DESCRIPTION
[NEWS](https://gitlab.gnome.org/GNOME/librsvg/-/blob/master/NEWS)  
