### PR TITLE
fix(Dockerfile): initialize git repo in VMAF source to satisfy vcstagger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,14 @@ ARG VMAF_SHA256=7178c4833639e6b989ecae73131d02f70735fdb3fc2c7d84bc36c9c3461d93b1
 RUN \
   wget $WGET_OPTS -O vmaf.tar.gz "$VMAF_URL" && \
   echo "$VMAF_SHA256  vmaf.tar.gz" | sha256sum -c - && \
-  tar $TAR_OPTS vmaf.tar.gz && cd vmaf-*/libvmaf && \
+  tar $TAR_OPTS vmaf.tar.gz && \
+  cd vmaf-* && \
+  git init && \
+  git config user.name "vmaf" && \
+  git config user.email "vmaf@example.com" && \
+  git add . && \
+  git commit -m "Initial commit" && \
+  cd libvmaf && \  
   meson setup build \
     -Dbuildtype=release \
     -Ddefault_library=static \


### PR DESCRIPTION
Summary:
This PR fixes the build error in the Dockerfile by initializing a minimal git repository in the VMAF source directory. The issue occurred during the Meson step (vcstagger) because the tarball lacked a .git folder.

Changes:

- Added commands to initialize a git repo and commit the extracted VMAF source before running Meson.
- This allows git describe to work correctly, resolving the fatal error during build.

Testing:
I built the image locally (using Podman on an Apple M3 Pro) and confirmed that the build now completes successfully without errors.