### PR TITLE
Update libssh to 0.11.2 from 0.11.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -642,9 +642,9 @@ RUN \
 # bump: libssh after ./hashupdate Dockerfile LIBSSH $LATEST
 # bump: libssh link "Source diff $CURRENT..$LATEST" https://gitlab.com/libssh/libssh-mirror/-/compare/libssh-$CURRENT...libssh-$LATEST
 # bump: libssh link "Release notes" https://gitlab.com/libssh/libssh-mirror/-/tags/libssh-$LATEST
-ARG LIBSSH_VERSION=0.11.1
+ARG LIBSSH_VERSION=0.11.2
 ARG LIBSSH_URL="https://gitlab.com/libssh/libssh-mirror/-/archive/libssh-$LIBSSH_VERSION/libssh-mirror-libssh-$LIBSSH_VERSION.tar.gz"
-ARG LIBSSH_SHA256=b43ef9c91b6c3db64e7ba3db101eb89dbe645db63489c19d4f88cf6f84911ec6
+ARG LIBSSH_SHA256=e28a8a6d37b285c1015fe38a015f450f66e7fdb8dd76be23e9e32ef9640f1859
 # LIBSSH_STATIC=1 is REQUIRED to link statically against libssh.a so add to pkg-config file
 RUN \
   wget $WGET_OPTS -O libssh.tar.gz "$LIBSSH_URL" && \


### PR DESCRIPTION
[Source diff 0.11.1..0.11.2](https://gitlab.com/libssh/libssh-mirror/-/compare/libssh-0.11.1...libssh-0.11.2)  
[Release notes](https://gitlab.com/libssh/libssh-mirror/-/tags/libssh-0.11.2)  
