### PR TITLE
Update libssh to 0.12.1 from 0.12.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -632,9 +632,9 @@ RUN \
 # bump: libssh after ./hashupdate Dockerfile LIBSSH $LATEST
 # bump: libssh link "Source diff $CURRENT..$LATEST" https://gitlab.com/libssh/libssh-mirror/-/compare/libssh-$CURRENT...libssh-$LATEST
 # bump: libssh link "Release notes" https://gitlab.com/libssh/libssh-mirror/-/tags/libssh-$LATEST
-ARG LIBSSH_VERSION=0.12.0
+ARG LIBSSH_VERSION=0.12.1
 ARG LIBSSH_URL="https://gitlab.com/libssh/libssh-mirror/-/archive/libssh-$LIBSSH_VERSION/libssh-mirror-libssh-$LIBSSH_VERSION.tar.gz"
-ARG LIBSSH_SHA256=dea4d0fca445522b1e40e02461f79b54a39f4d7e6814d616a5714eb0b64c3e2e
+ARG LIBSSH_SHA256=8c45cb01fbd373334561fd6d1bbe124cdc6ef541c17fc17dee10747ce2d6433f
 # LIBSSH_STATIC=1 is REQUIRED to link statically against libssh.a so add to pkg-config file
 RUN \
   wget $WGET_OPTS -O libssh.tar.gz "$LIBSSH_URL" && \


### PR DESCRIPTION
[Source diff 0.12.0..0.12.1](https://gitlab.com/libssh/libssh-mirror/-/compare/libssh-0.12.0...libssh-0.12.1)  
[Release notes](https://gitlab.com/libssh/libssh-mirror/-/tags/libssh-0.12.1)  
